### PR TITLE
Add BERT-based article analysis

### DIFF
--- a/client/src/__tests__/NewsCard.test.jsx
+++ b/client/src/__tests__/NewsCard.test.jsx
@@ -1,5 +1,5 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import NewsCard from '../components/NewsCard.jsx';
 
 const article = {
@@ -11,6 +11,16 @@ const article = {
   publishedAt: '2024-01-01T00:00:00Z'
 };
 
+beforeEach(() => {
+  global.fetch = vi.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve({ summary: 'sum', sentiment: 'positive' }) })
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe('NewsCard', () => {
   it('renders title and link', () => {
     render(<NewsCard article={article} />);
@@ -18,10 +28,10 @@ describe('NewsCard', () => {
     expect(screen.getByRole('link', { name: /Read full article/i })).toHaveAttribute('href', 'http://example.com');
   });
 
-  it('toggles expansion', () => {
+  it('toggles expansion', async () => {
     render(<NewsCard article={article} />);
     const button = screen.getAllByRole('button')[0];
     fireEvent.click(button);
-    expect(button.textContent).toMatch(/Show less/);
+    await waitFor(() => expect(button.textContent).toMatch(/Show less/));
   });
 });

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,8 @@
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "graphql": "^16.8.1",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@xenova/transformers": "^2.5.4"
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/server/src/ai/bertAnalyzer.js
+++ b/server/src/ai/bertAnalyzer.js
@@ -1,0 +1,38 @@
+const { pipeline } = require('@xenova/transformers');
+
+/**
+ * Analyzer using BERT-based models for summarization and sentiment analysis
+ */
+class BertAnalyzer {
+  constructor() {
+    this.loaders = {
+      summarizer: null,
+      sentiment: null,
+    };
+  }
+
+  async loadModels() {
+    if (!this.loaders.summarizer) {
+      this.loaders.summarizer = pipeline('summarization', 'Xenova/bart-large-cnn');
+    }
+    if (!this.loaders.sentiment) {
+      this.loaders.sentiment = pipeline('sentiment-analysis', 'Xenova/distilbert-base-uncased-finetuned-sst-2-english');
+    }
+    this.summarizer = await this.loaders.summarizer;
+    this.sentiment = await this.loaders.sentiment;
+  }
+
+  async summarize(text) {
+    await this.loadModels();
+    const result = await this.summarizer(text, { max_length: 60 });
+    return result[0]?.summary_text || '';
+  }
+
+  async analyzeSentiment(text) {
+    await this.loadModels();
+    const result = await this.sentiment(text);
+    return result[0]?.label.toLowerCase() || 'neutral';
+  }
+}
+
+module.exports = BertAnalyzer;


### PR DESCRIPTION
## Summary
- integrate `@xenova/transformers` in the backend
- create `BertAnalyzer` for summarization and sentiment analysis
- expose new `/api/analyze` endpoint
- fetch live article analysis from the client on expand
- display summary and sentiment in `NewsCard`
- update tests to mock fetch

## Testing
- `npm test` in `client`
- `npm test` in `server`

------
https://chatgpt.com/codex/tasks/task_e_684fb97a3424832f9a09b7a4e407b1a0