### PR TITLE
Fix LangGraph integration

### DIFF
--- a/server/src/ai/newsAggregator.js
+++ b/server/src/ai/newsAggregator.js
@@ -1,5 +1,4 @@
 const { ChatOpenAI } = require('@langchain/openai');
-const { createGraph, StateGraph } = require('@langchain/langgraph');
 const { StringOutputParser } = require('@langchain/core/output_parsers');
 const { ChatPromptTemplate } = require('@langchain/core/prompts');
 const config = require('../config/config');

--- a/server/src/ai/newsOrchestrator.js
+++ b/server/src/ai/newsOrchestrator.js
@@ -1,4 +1,4 @@
-const { createGraph, StateGraph } = require('@langchain/langgraph');
+const { StateGraph } = require('@langchain/langgraph');
 const NewsProcessor = require('./newsProcessor');
 
 /**
@@ -23,7 +23,11 @@ class NewsOrchestrator {
     };
 
     // Create the graph
-    const builder = createGraph(graphState);
+    const builder = new StateGraph({ channels: {
+      article: {},
+      processedData: {},
+      error: {},
+    }});
 
     // Define the nodes
     builder.addNode("summarize", async (state) => {
@@ -188,7 +192,11 @@ class NewsOrchestrator {
     };
 
     // Create the graph
-    const builder = createGraph(graphState);
+    const builder = new StateGraph({ channels: {
+      articles: {},
+      processedArticles: {},
+      errors: {},
+    }});
 
     // Define the nodes
     builder.addNode("processArticles", async (state) => {


### PR DESCRIPTION
## Summary
- update NewsOrchestrator to use `StateGraph` constructor
- remove unused `createGraph` import from NewsAggregator

## Testing
- `npm test --prefix server`

------
https://chatgpt.com/codex/tasks/task_e_6851e8899394832f97bc9f784180505e